### PR TITLE
Changed order of execution of docker file for skd drivers intalation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,10 @@ ENV SONIA_WS_SETUP=${SONIA_WS}/devel/setup.bash
 RUN apt-get update \
     && apt-get install -y libunwind-dev
 
-WORKDIR ${SONIA_WS}
-
-COPY . ${NODE_PATH}
-
 WORKDIR ${NODE_PATH}/drivers/${TARGET_ARCH}
+
+#Copy the drivers to install the spinnaker sdk
+COPY ./drivers/${TARGET_ARCH} .
 
 RUN chmod +x install_spinnaker.sh \
      && sh install_spinnaker.sh < input
@@ -45,6 +44,9 @@ RUN bash -c "source /etc/profile.d/setup_flir_gentl_64.sh 64"
 ENV FLIR_GENTL64_CTI=/opt/spinnaker/lib/flir-gentl/FLIR_GenTL.cti
 
 WORKDIR ${SONIA_WS}
+
+#Copy the code of provider_vision and the rest (changes more often then the sdk)
+COPY . ${NODE_PATH}
 
 RUN bash -c "source ${ROS_WS_SETUP}; source ${BASE_LIB_WS_SETUP}; catkin_make"
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>provider_vision</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>The provider_vision package - Point Grey Spinnaker based camera driver</description>
 
   <author>Abhishek Bajpayee</author>


### PR DESCRIPTION
also, bumped the version in package.xml.

## Description
Help with the build time of the docker image for provider_vision.
The spinnaker drivers are now installed before copying the rest of the provider vision project.
This way, docker can use the cashed state of the image with the drivers already installed when possible and only rebuild the rest that has changed after.

## Fixes
Link all the related issues from the issue tracker
- Closes: #3 

## How has this been tested ?
- Tested the docker locally by checking if it runs.
- Tested by the workflow on GitHub.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings